### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/Magabot/keywords.txt
+++ b/Magabot/keywords.txt
@@ -31,10 +31,10 @@ irState	LITERAL1
 irMaxValue	LITERAL1
 sonarRead	LITERAL1
 leftClicks 	LITERAL1
-rightClicks LITERAL1
-leftMotorVelocity LITERAL1
-rightMotorVelocity LITERAL1
-clicksPerTurn LITERAL1
+rightClicks	LITERAL1
+leftMotorVelocity	LITERAL1
+rightMotorVelocity	LITERAL1
+clicksPerTurn	LITERAL1
 sonarMaxValue	LITERAL1
 sonarValue	LITERAL1
 bumperRead	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords